### PR TITLE
Avoid venv usage in python scripts used in database

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "ext/ESP8266SdFat"]
 	path = ext/ESP8266SdFat
 	url = https://github.com/sd2psx/ESP8266SdFat.git
+[submodule "ext/unidecode"]
+	path = ext/unidecode
+	url = https://github.com/avian2/unidecode.git

--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -7,6 +7,8 @@ add_custom_target(gamedbobjs_ps1 ALL
                         -D PYTHON_SCRIPT=${CMAKE_CURRENT_SOURCE_DIR}/parse_GameDB.py
                         -D CMAKE_OBJCOPY=${CMAKE_OBJCOPY}
                         -D SYSTEM=ps1
+                        -D "INPUT_URLS=https://github.com/niemasd/GameDB-PSX/releases/latest/download/PSX.data.json"
+                        -D "REPO_ROOT=${CMAKE_SOURCE_DIR}"
                         -P ${CMAKE_CURRENT_SOURCE_DIR}/db_obj_builder.cmake
                     VERBATIM
                     BYPRODUCTS ${GAMEDB_PS1_OBJ})
@@ -26,6 +28,8 @@ add_custom_target(gamedbobjs_ps2 ALL
                         -D PYTHON_SCRIPT=${CMAKE_CURRENT_SOURCE_DIR}/get_and_parse_hdldb.py
                         -D CMAKE_OBJCOPY=${CMAKE_OBJCOPY}
                         -D SYSTEM=ps2
+                        -D "INPUT_URLS=https://github.com/israpps/HDL-Batch-installer/raw/main/Database/gamename.csv"
+                        -D "REPO_ROOT=${CMAKE_SOURCE_DIR}"
                         -P ${CMAKE_CURRENT_SOURCE_DIR}/db_obj_builder.cmake
                     VERBATIM
                     BYPRODUCTS ${GAMEDB_PS2_OBJ})
@@ -44,6 +48,8 @@ add_custom_target(gamedbobjs_coh ALL
                         -D PYTHON_SCRIPT=${CMAKE_CURRENT_SOURCE_DIR}/parse_arcade.py
                         -D CMAKE_OBJCOPY=${CMAKE_OBJCOPY}
                         -D SYSTEM=coh
+                        -D "INPUT_URLS=https://raw.githubusercontent.com/israpps/AthenaEnv/refs/heads/aclauncher/bin/aclauncher/246.json;https://raw.githubusercontent.com/israpps/AthenaEnv/refs/heads/aclauncher/bin/aclauncher/256.json"
+                        -D "REPO_ROOT=${CMAKE_SOURCE_DIR}"
                         -P ${CMAKE_CURRENT_SOURCE_DIR}/db_obj_builder.cmake
                     VERBATIM
                     BYPRODUCTS ${GAMEDB_COH_OBJ})

--- a/database/db_obj_builder.cmake
+++ b/database/db_obj_builder.cmake
@@ -1,35 +1,24 @@
 string(TIMESTAMP date "%Y%m%d")
 
+set(GAMEDB_${SYSTEM}_IN "gamedb${SYSTEM}_input")
 set(GAMEDB_${SYSTEM}_BIN "gamedb${SYSTEM}.dat")
 set(GAMEDB_${SYSTEM}_OBJ "${OUTPUT_DIR}/gamedb${SYSTEM}_${date}.o")
 
 if(NOT EXISTS "${GAMEDB_${SYSTEM}_OBJ}")
 
-find_package (Python3 COMPONENTS Interpreter)
-execute_process (COMMAND "${Python3_EXECUTABLE}" -m venv "${OUTPUT_DIR}/db_builder")
-
-# Here is the trick
-## update the environment with VIRTUAL_ENV variable (mimic the activate script)
-set (ENV{VIRTUAL_ENV} "${OUTPUT_DIR}/db_builder")
-## change the context of the search
-set (Python3_FIND_VIRTUALENV FIRST)
-## unset Python3_EXECUTABLE because it is also an input variable (see documentation, Artifacts Specification section)
-unset (Python3_EXECUTABLE)
-## Launch a new search
 find_package (Python3 COMPONENTS Interpreter Development)
 
 file(GLOB files "${OUTPUT_DIR}/gamedb${SYSTEM}_*")
 foreach(file ${files})
 file(REMOVE "${file}")
 endforeach()
-
+file(MAKE_DIRECTORY ${GAMEDB_${SYSTEM}_IN})
+foreach(url ${INPUT_URLS})
+get_filename_component(url_BASENAME ${url} NAME)
+file(DOWNLOAD "${url}" "${GAMEDB_${SYSTEM}_IN}/${url_BASENAME}")
+endforeach()
 execute_process(
-    COMMAND ${Python3_EXECUTABLE} -m pip install requests unidecode
-    WORKING_DIRECTORY ${OUTPUT_DIR}
-    OUTPUT_QUIET
-)
-execute_process(
-    COMMAND ${Python3_EXECUTABLE} ${PYTHON_SCRIPT} ${SYSTEM} ${OUTPUT_DIR}
+    COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${REPO_ROOT}/ext/unidecode" ${Python3_EXECUTABLE} ${PYTHON_SCRIPT} ${SYSTEM} ${OUTPUT_DIR} "${GAMEDB_${SYSTEM}_IN}" "${GAMEDB_${SYSTEM}_BIN}"
     WORKING_DIRECTORY ${OUTPUT_DIR}
     OUTPUT_QUIET
 )

--- a/database/get_and_parse_hdldb.py
+++ b/database/get_and_parse_hdldb.py
@@ -1,4 +1,4 @@
-import requests
+import sys
 import csv
 from unidecode import unidecode
 
@@ -71,13 +71,12 @@ def getGamesHDLBatchInstaller() -> ([], [], {}, int):
     games_sorted = {}
     games_count = 0
 
-    url = "https://github.com/israpps/HDL-Batch-installer/raw/main/Database/gamename.csv"
+    data = ""
+    with open(sys.argv[3] + "/gamename.csv", "r") as f:
+        data = f.read()
 
-    r = requests.get(url, allow_redirects=True)
-
-
-    if r.status_code == 200:
-        lines = r.text.split("\n")
+    if True:
+        lines = data.split("\n")
         csv_reader = csv.reader(lines, delimiter=";")
         for row in csv_reader:
             if len(row) == 2:
@@ -108,7 +107,7 @@ games_sorted = {}
 games_count = 0
 
 
-with open("gamedbps2.dat", "wb") as out:
+with open(sys.argv[4], "wb") as out:
     (prefixes, gamenames, games_sorted, games_count) = getGamesHDLBatchInstaller()
     writeSortedGameList(out, prefixes, games_count, games_sorted, gamenames)
 

--- a/database/parse_GameDB.py
+++ b/database/parse_GameDB.py
@@ -1,4 +1,4 @@
-import requests
+import sys
 import json
 import re
 from unidecode import unidecode
@@ -78,13 +78,13 @@ def getGamesGameDB() -> ([], [], {}, int):
     games_count = 0
     name_to_serials = {}
 
-    url = "https://github.com/niemasd/GameDB-PSX/releases/latest/download/PSX.data.json"
+    data = ""
+    with open(sys.argv[3] + "/PSX.data.json", "r") as f:
+        data = f.read()
 
-    r = requests.get(url, allow_redirects=True)
 
-
-    if r.status_code == 200:
-        input = json.loads(r.text)
+    if True:
+        input = json.loads(data)
         for id in input:
             try:
                 if "redump_name" in input[id]:
@@ -133,7 +133,7 @@ games_sorted = {}
 games_count = 0
 
 
-with open("gamedbps1.dat", "wb") as out:
+with open(sys.argv[4], "wb") as out:
     (prefixes, gamenames, games_sorted, games_count) = getGamesGameDB()
     writeSortedGameList(out, prefixes, games_count, games_sorted, gamenames)
 

--- a/database/parse_arcade.py
+++ b/database/parse_arcade.py
@@ -1,14 +1,14 @@
-import requests
+import sys
 import json
 
 def getGamesGameDB(system) -> dict[str, str]:
-    url = f"https://raw.githubusercontent.com/israpps/AthenaEnv/refs/heads/aclauncher/bin/aclauncher/{system}.json"
-
-    r = requests.get(url, allow_redirects=True)
+    data = ""
+    with open(sys.argv[3] + "/" + system + ".json", "r") as f:
+        data = f.read()
     games = {}
 
-    if r.status_code == 200:
-        input = json.loads(r.text)
+    if True:
+        input = json.loads(data)
         for game in input["games"]:
             id = game["gameid"]
             if "NM" in id:
@@ -30,13 +30,7 @@ def getGamesGameDB(system) -> dict[str, str]:
 
     return games
 
-import argparse
-parser = argparse.ArgumentParser()
-parser.add_argument("dirname")
-parser.add_argument("outputdir")
-args = parser.parse_args()
-
-filename = "gamedbcoh.dat"
+filename = sys.argv[4]
 
 # Get games from GameDB:
 


### PR DESCRIPTION
This basically avoids the venv hack workaround used in the CMake script, avoiding the "User site-packages are not visible in this virtualenv" error on a stock Ubuntu image.