### PR TITLE
add new Option MaxCardIdx [PS1,PS2] and EnableControllerCombo [PS1]

### DIFF
--- a/src/ps1/ps1_cardman.c
+++ b/src/ps1/ps1_cardman.c
@@ -329,11 +329,14 @@ void ps1_cardman_next_idx(void) {
         case PS1_CM_STATE_NORMAL:
             card_idx += 1;
             card_chan = CHAN_MIN;
-            uint8_t maxcards = settings_get_ps1_maxcards();
-            if (maxcards < IDX_MIN)
-                maxcards = IDX_MIN;
-            if (card_idx > maxcards) //dont jump to IDX_MIN. Otherwise without display, you cant see where you actually are.
-                card_idx = maxcards;
+            if (card_idx > UINT16_MAX)
+                card_idx = UINT16_MAX;
+            uint8_t maxcards = settings_get_ps1_maxcardidx();
+            if (maxcards != 0) //0 = unlimited cards UINT16_MAX
+            {
+                if (card_idx > maxcards)
+                    card_idx = maxcards;
+            }
             snprintf(folder_name, sizeof(folder_name), "Card%d", card_idx);
             break;
     }

--- a/src/ps1/ps1_cardman.c
+++ b/src/ps1/ps1_cardman.c
@@ -59,6 +59,9 @@ static void set_default_card() {
     card_chan = settings_get_ps1_channel();
     cardman_state = PS1_CM_STATE_NORMAL;
     snprintf(folder_name, sizeof(folder_name), "Card%d", card_idx);
+    uint8_t max_chan = card_config_get_max_channels(folder_name, folder_name);
+    if (card_chan > max_chan)
+        card_chan = max_chan;
 }
 
 static bool try_set_game_id_card() {
@@ -287,7 +290,7 @@ void ps1_cardman_next_channel(void) {
         case PS1_CM_STATE_NORMAL:
             card_chan += 1;
             if (card_chan > max_chan)
-                card_chan = CHAN_MIN;
+                card_chan = max_chan; //dont jump to CHAN_MIN. Otherwise without display, you cant see where you actually are.
             break;
     }
 
@@ -304,7 +307,7 @@ void ps1_cardman_prev_channel(void) {
         case PS1_CM_STATE_NORMAL:
             card_chan -= 1;
             if (card_chan < CHAN_MIN)
-                card_chan = max_chan;
+                card_chan = CHAN_MIN; //dont jump to max_chan. Otherwise without display, you cant see where you actually are.
             break;
     }
     needs_update = true;
@@ -326,8 +329,11 @@ void ps1_cardman_next_idx(void) {
         case PS1_CM_STATE_NORMAL:
             card_idx += 1;
             card_chan = CHAN_MIN;
-            if (card_idx > UINT16_MAX)
-                card_idx = UINT16_MAX;
+            uint8_t maxcards = settings_get_ps1_maxcards();
+            if (maxcards < IDX_MIN)
+                maxcards = IDX_MIN;
+            if (card_idx > maxcards) //dont jump to IDX_MIN. Otherwise without display, you cant see where you actually are.
+                card_idx = maxcards;
             snprintf(folder_name, sizeof(folder_name), "Card%d", card_idx);
             break;
     }

--- a/src/ps1/ps1_memory_card.c
+++ b/src/ps1/ps1_memory_card.c
@@ -353,6 +353,10 @@ static void mc_read_controller(void) {
     static uint8_t prevCommand = 0;
     uint8_t controller_in[2];
     uint8_t _ = 0x00;
+
+    if (!settings_get_ps1_controllercombo())
+        return;
+
     receiveOrNextCmd(&_);
     if (_ == (uint8_t)'B') {    // Only reactive to "read buttons" command
         receiveOrNextCntrl(&_); // Hi-Z

--- a/src/ps1/ps1_memory_card.c
+++ b/src/ps1/ps1_memory_card.c
@@ -354,9 +354,6 @@ static void mc_read_controller(void) {
     uint8_t controller_in[2];
     uint8_t _ = 0x00;
 
-    if (!settings_get_ps1_controllercombo())
-        return;
-
     receiveOrNextCmd(&_);
     if (_ == (uint8_t)'B') {    // Only reactive to "read buttons" command
         receiveOrNextCntrl(&_); // Hi-Z
@@ -460,7 +457,7 @@ static void __time_critical_func(mc_main_loop)(void) {
                 case 'W': mc_cmd_write(); break;
                 default: DPRINTF("Unknown command: 0x%.02x\n", ch); break;
             }
-        } else if (0x01 == ch) {
+        } else if ((0x01 == ch) && (settings_get_ps1_controllercombo())) {
             mc_read_controller();
         } else if ((0x21 == ch) && !ps2_multitap) {
             ps1_mc_respond(0x00);

--- a/src/ps2/ps2_cardman.c
+++ b/src/ps2/ps2_cardman.c
@@ -87,6 +87,9 @@ static void set_default_card() {
     card_chan = settings_get_ps2_channel();
     cardman_state = PS2_CM_STATE_NORMAL;
     snprintf(folder_name, sizeof(folder_name), "Card%d", card_idx);
+    uint8_t max_chan = card_config_get_max_channels(folder_name, folder_name);
+    if (card_chan > max_chan)
+        card_chan = max_chan;
 }
 
 static bool try_set_game_id_card() {
@@ -649,7 +652,7 @@ void ps2_cardman_next_channel(void) {
     uint8_t max_chan = card_config_get_max_channels(folder_name, (cardman_state == PS2_CM_STATE_BOOT) ? "BootCard" : folder_name);
     card_chan += 1;
     if (card_chan > max_chan)
-        card_chan = CHAN_MIN;
+        card_chan = max_chan; //dont jump to CHAN_MIN. Otherwise without display, you cant see where you actually are.
     needs_update = true;
 }
 
@@ -657,7 +660,7 @@ void ps2_cardman_prev_channel(void) {
     uint8_t max_chan = card_config_get_max_channels(folder_name, (cardman_state == PS2_CM_STATE_BOOT) ? "BootCard" : folder_name);
     card_chan -= 1;
     if (card_chan < CHAN_MIN)
-        card_chan = max_chan;
+        card_chan = CHAN_MIN; //dont jump to max_chan. Otherwise without display, you cant see where you actually are.
     needs_update = true;
 }
 
@@ -695,6 +698,12 @@ void ps2_cardman_next_idx(void) {
             card_chan = CHAN_MIN;
             if (card_idx > UINT16_MAX)
                 card_idx = UINT16_MAX;
+            uint8_t maxcards = settings_get_ps2_maxcardidx();
+            if (maxcards != 0) //0 = unlimited cards UINT16_MAX
+            {
+                if (card_idx > maxcards)
+                    card_idx = maxcards;
+            }
             snprintf(folder_name, sizeof(folder_name), "Card%d", card_idx);
             break;
     }

--- a/src/settings.c
+++ b/src/settings.c
@@ -40,7 +40,7 @@ typedef struct {
     uint8_t sys_flags;
     uint8_t ps2_cardsize;
     uint8_t ps2_variant; // Variant for keys
-    uint8_t ps1_maxcardidx
+    uint8_t ps1_maxcardidx;
     uint8_t ps2_maxcardidx;
 } serialized_settings_t;
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -30,6 +30,7 @@ typedef struct {
     uint8_t ps2_cardsize;
     // TODO: how do we store last used channel for cards that use autodetecting w/ gameid?
     uint8_t ps2_variant; // Variant for keys
+    uint8_t ps1_maxcards;    //1-255
 } settings_t;
 
 typedef struct {
@@ -38,19 +39,21 @@ typedef struct {
     uint8_t sys_flags;
     uint8_t ps2_cardsize;
     uint8_t ps2_variant; // Variant for keys
+    uint8_t ps1_maxcards;
 } serialized_settings_t;
 
 #define SETTINGS_UPDATE_FIELD(field) settings_update_part(&settings.field, sizeof(settings.field))
 
-#define SETTINGS_VERSION_MAGIC              (0xAACD0006)
+#define SETTINGS_VERSION_MAGIC              (0xAACD0007)
 #define SETTINGS_PS1_FLAGS_AUTOBOOT         (0b0000001)
 #define SETTINGS_PS1_FLAGS_GAME_ID          (0b0000010)
+#define SETTINGS_PS1_FLAGS_CTRL_COMBO       (0b0000100)
 #define SETTINGS_PS2_FLAGS_AUTOBOOT         (0b0000001)
 #define SETTINGS_PS2_FLAGS_GAME_ID          (0b0000010)
 #define SETTINGS_SYS_FLAGS_PS2_MODE         (0b0000001)
 #define SETTINGS_SYS_FLAGS_FLIPPED_DISPLAY  (0b0000010)
 
-_Static_assert(sizeof(settings_t) == 20, "unexpected padding in the settings structure");
+_Static_assert(sizeof(settings_t) == 24, "unexpected padding in the settings structure");
 
 static settings_t settings;
 static serialized_settings_t serialized_settings;
@@ -71,12 +74,18 @@ static int parse_card_configuration(void *user, const char *section, const char 
     } else if (MATCH("PS1", "GameID")
         && DIFFERS(value, ((_s->ps1_flags & SETTINGS_PS1_FLAGS_GAME_ID) > 0))) {
         _s->ps1_flags ^= SETTINGS_PS1_FLAGS_GAME_ID;
+    } else if (MATCH("PS1", "EnableControllerCombo")
+        && DIFFERS(value, ((_s->ps1_flags & SETTINGS_PS1_FLAGS_CTRL_COMBO) > 0))) {
+        _s->ps1_flags ^= SETTINGS_PS1_FLAGS_CTRL_COMBO;
+    } else if (MATCH("PS1", "MaxCards")) {
+         int maxcard = atoi(value);
+         _s->ps1_maxcards = maxcard;
     } else if (MATCH("PS2", "Autoboot")
         && DIFFERS(value, ((_s->ps2_flags & SETTINGS_PS2_FLAGS_AUTOBOOT) > 0))) {
         _s->ps2_flags ^= SETTINGS_PS2_FLAGS_AUTOBOOT;
     } else if (MATCH("PS2", "GameID")
         && DIFFERS(value, ((_s->ps2_flags & SETTINGS_PS2_FLAGS_GAME_ID) > 0))) {
-        _s->ps1_flags ^= SETTINGS_PS2_FLAGS_GAME_ID;
+        _s->ps2_flags ^= SETTINGS_PS2_FLAGS_GAME_ID;
     } else if (MATCH("PS2", "CardSize")) {
         int size = atoi(value);
         switch (size) {
@@ -121,18 +130,20 @@ static void settings_deserialize(void) {
                                              .sys_flags = settings.sys_flags,
                                              .ps2_cardsize = settings.ps2_cardsize,
                                              .ps2_variant = settings.ps2_variant,
-                                             .ps1_flags = settings.ps1_flags};
+                                             .ps1_flags = settings.ps1_flags,
+                                             .ps1_maxcards = settings.ps1_maxcards};
         serialized_settings = newSettings;
         ini_parse_sd_file(fd, parse_card_configuration, &newSettings);
         sd_close(fd);
         if (memcmp(&newSettings, &serialized_settings, sizeof(serialized_settings))) {
             printf("Updating settings from ini\n");
-            serialized_settings = newSettings;
+            serialized_settings      = newSettings;
             settings.sys_flags       = newSettings.sys_flags;
             settings.ps2_flags       = newSettings.ps2_flags;
             settings.ps2_cardsize    = newSettings.ps2_cardsize;
             settings.ps2_variant     = newSettings.ps2_variant;
             settings.ps1_flags       = newSettings.ps1_flags;
+            settings.ps1_maxcards    = newSettings.ps1_maxcards;
 
             wear_leveling_write(0, &settings, sizeof(settings));
         }
@@ -142,7 +153,8 @@ static void settings_deserialize(void) {
 static void settings_serialize(void) {
     int fd;
     // Only serialize if required
-    if (serialized_settings.ps2_cardsize == settings.ps2_cardsize &&
+    if (serialized_settings.ps1_maxcards == settings.ps1_maxcards &&
+        serialized_settings.ps2_cardsize == settings.ps2_cardsize &&
         serialized_settings.ps2_flags == settings.ps2_flags &&
         serialized_settings.sys_flags == settings.sys_flags &&
         serialized_settings.ps2_variant == settings.ps2_variant &&
@@ -170,6 +182,10 @@ static void settings_serialize(void) {
         sd_write(fd, line_buffer, written);
         written = snprintf(line_buffer, 256, "GameID=%s\n", ((settings.ps1_flags & SETTINGS_PS1_FLAGS_GAME_ID) > 0) ? "ON" : "OFF");
         sd_write(fd, line_buffer, written);
+        written = snprintf(line_buffer, 256, "EnableControllerCombo=%s\n", ((settings.ps1_flags & SETTINGS_PS1_FLAGS_CTRL_COMBO) > 0) ? "ON" : "OFF");
+        sd_write(fd, line_buffer, written);		
+        written = snprintf(line_buffer, 256, "MaxCards=%u\n", settings.ps1_maxcards);
+        sd_write(fd, line_buffer, written);		
         written = snprintf(line_buffer, 256, "[PS2]\n");
         sd_write(fd, line_buffer, written);
         written = snprintf(line_buffer, 256, "Autoboot=%s\n", ((settings.ps2_flags & SETTINGS_PS2_FLAGS_AUTOBOOT) > 0) ? "ON" : "OFF");
@@ -203,6 +219,7 @@ static void settings_serialize(void) {
     serialized_settings.ps2_cardsize    = settings.ps2_cardsize;
     serialized_settings.ps2_variant     = settings.ps2_variant;
     serialized_settings.ps1_flags       = settings.ps1_flags;
+    serialized_settings.ps1_maxcards 	= settings.ps1_maxcards;
 }
 
 static void settings_reset(void) {
@@ -211,10 +228,11 @@ static void settings_reset(void) {
     settings.display_timeout = 0; // off
     settings.display_contrast = 255; // 100%
     settings.display_vcomh = 0x30; // 0.83 x VCC
-    settings.ps1_flags = SETTINGS_PS1_FLAGS_GAME_ID;
+    settings.ps1_flags = SETTINGS_PS1_FLAGS_GAME_ID | SETTINGS_PS1_FLAGS_CTRL_COMBO;
     settings.ps2_flags = SETTINGS_PS2_FLAGS_GAME_ID;
     settings.ps2_cardsize = 8;
     settings.ps2_variant = PS2_VARIANT_RETAIL;
+    settings.ps1_maxcards = UINT8_MAX;
     if (wear_leveling_write(0, &settings, sizeof(settings)) == WEAR_LEVELING_FAILED)
         fatal(ERR_SETTINGS, "failed to reset settings");
 }
@@ -284,6 +302,10 @@ int settings_get_ps2_variant(void) {
     return settings.ps2_variant;
 }
 
+uint8_t settings_get_ps1_maxcards(void) {
+    return settings.ps1_maxcards;
+}
+
 void settings_set_ps2_card(int card) {
     if (card != settings.ps2_card) {
         settings.ps2_card = card;
@@ -319,10 +341,18 @@ void settings_set_ps2_variant(int x) {
     }
 }
 
+void settings_set_ps1_maxcards(uint8_t x) {
+    if (settings.ps1_maxcards != x) {
+        settings.ps1_maxcards = x;
+        SETTINGS_UPDATE_FIELD(ps1_maxcards);
+    }
+}
 
 int settings_get_ps1_card(void) {
     if (settings.ps1_card < IDX_MIN)
         return IDX_MIN;
+    else if (settings.ps1_card > settings.ps1_maxcards)
+        return settings.ps1_maxcards;
     return settings.ps1_card;
 }
 
@@ -401,6 +431,16 @@ bool settings_get_ps1_game_id(void) {
 void settings_set_ps1_game_id(bool enabled) {
     if (enabled != settings_get_ps1_game_id())
         settings.ps1_flags ^= SETTINGS_PS1_FLAGS_GAME_ID;
+    SETTINGS_UPDATE_FIELD(ps1_flags);
+}
+
+bool settings_get_ps1_controllercombo(void) {
+    return (settings.ps1_flags & SETTINGS_PS1_FLAGS_CTRL_COMBO);
+}
+
+void settings_set_ps1_controllercombo(bool controllercombo) {
+    if (controllercombo != settings_get_ps1_controllercombo())
+        settings.ps1_flags ^= SETTINGS_PS1_FLAGS_CTRL_COMBO;
     SETTINGS_UPDATE_FIELD(ps1_flags);
 }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -12,6 +12,10 @@ int settings_get_ps1_boot_channel(void);
 void settings_set_ps1_card(int x);
 void settings_set_ps1_channel(int x);
 void settings_set_ps1_boot_channel(int x);
+bool settings_get_ps1_controllercombo(void);
+void settings_set_ps1_controllercombo(bool controllercombo);
+uint8_t settings_get_ps1_maxcards(void);
+void settings_set_ps1_maxcards(uint8_t x);
 
 int settings_get_ps2_card(void);
 int settings_get_ps2_channel(void);

--- a/src/settings.h
+++ b/src/settings.h
@@ -14,8 +14,8 @@ void settings_set_ps1_channel(int x);
 void settings_set_ps1_boot_channel(int x);
 bool settings_get_ps1_controllercombo(void);
 void settings_set_ps1_controllercombo(bool controllercombo);
-uint8_t settings_get_ps1_maxcards(void);
-void settings_set_ps1_maxcards(uint8_t x);
+uint8_t settings_get_ps1_maxcardidx(void);
+void settings_set_ps1_maxcardidx(uint8_t x);
 
 int settings_get_ps2_card(void);
 int settings_get_ps2_channel(void);
@@ -27,6 +27,8 @@ void settings_set_ps2_channel(int x);
 void settings_set_ps2_boot_channel(int x);
 void settings_set_ps2_cardsize(uint8_t size);
 void settings_set_ps2_variant(int x);
+uint8_t settings_get_ps2_maxcardidx(void);
+void settings_set_ps2_maxcardidx(uint8_t x);
 
 enum {
     MODE_PS1 = 0,


### PR DESCRIPTION
New options for the settings.ini to enable/disable `EnableControllerCombo` the PS1 controller combo (switch card or channel) and limit the max number of cards `MaxCardIdx`. When you switch channels and reach the end/beginning, you no longer jump to the beginning/end. This is very useful with cards w/o display. And I fixed the deserialisation bug for PS2 GameID.


**settings.ini example:**
```
[PS1]
...
EnableControllerCombo=ON    <- default
MaxCardIdx=2
...
[PS2]
...
MaxCardIdx=0       <- 0 = default, unlimited (old behavior)
```

The maximum number of channels has already been included.
**Card1.ini example:**
```
[ChannelName]
1=Channel1
[Settings]
MaxChannels=1
CardSize=8
```


See issue for details:
https://github.com/sd2psXtd/firmware/issues/73

I was able to successfully test the PS1 options. However, I cannot test the PS2 MaxCardIdx option because I do not have one.