### PR TITLE
[PS2 0xF7] consider only first two bits of parameter

### DIFF
--- a/src/ps2/card_emu/ps2_mc_auth.c
+++ b/src/ps2/card_emu/ps2_mc_auth.c
@@ -573,7 +573,7 @@ inline __attribute__((always_inline)) void __time_critical_func(ps2_mc_auth_keyS
     receiveOrNextCmd(&_);
     DPRINTF("KeySelect: requested %d key\n", _);
     if (PS2_VARIANT_RETAIL == settings_get_ps2_variant()) {
-        switch (_) {
+        switch (_ & 0x03) {
             case REQUEST_DEX:
                 keysource = ps2_keysource;
                 key = dex_key;


### PR DESCRIPTION
original SCPH-10020 do this, so for example, a parameter 0xF would be as sending 0x0