### PR TITLE
Make card harmless when plugged in ps2 mode into ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,7 @@ When launching in PS2 mode, commands sent to *sd2psx* are monitored. Since PS1 s
 While in general this should be safe behavior, if *sd2psx* is used mainly in PS1, manual mode selection is recommended.
 
 > [!CAUTION]
-> **Note 1:** If *sd2psx* is connected to a PS1 in PS2 mode, there is always a risk of damaging your PS1 console. You have been warned!
-
-> [!CAUTION]
-> **Note 2:** Do not use *sd2psx* in dynamic mode on a PS1 multitap, as this **WILL** damage your PS1 multitap device.
+> If *sd2psx* is connected to a PS1 or a PS1 multitap in PS2 mode, there is always a risk of damaging your console / multitap. Safeguards have been implemented to minimize this risk, but they are not entirely foolproof. You have been warned!
 
 ## PS2: MMCEMAN and MMCEDRV Support
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -727,15 +727,15 @@ static void create_menu_screen(void) {
         lv_obj_t *ps2_switch_warn = ui_menu_subpage_create(menu, NULL);
         {
             cont = ui_menu_cont_create(ps2_switch_warn);
-            ui_label_create(cont, "Do not insert");
+            ui_label_create(cont, "Avoid insert in");
             cont = ui_menu_cont_create(ps2_switch_warn);
-            ui_label_create(cont, "into PS1 when");
+            ui_label_create(cont, "PS1 while in PS2");
             cont = ui_menu_cont_create(ps2_switch_warn);
-            ui_label_create(cont, "set to PS2 mode!");
+            ui_label_create(cont, "mode. Safeguards");
             cont = ui_menu_cont_create(ps2_switch_warn);
-            ui_label_create(cont, "It may damage");
+            ui_label_create(cont, "may not prevent");
             cont = ui_menu_cont_create(ps2_switch_warn);
-            ui_label_create(cont, "card and console");
+            ui_label_create(cont, "all damage.");
 
             cont = ui_menu_cont_create_nav(ps2_switch_warn);
             ui_label_create(cont, "Confirm");

--- a/src/ps2/card_emu/ps2_mc_spi.pio
+++ b/src/ps2/card_emu/ps2_mc_spi.pio
@@ -83,11 +83,16 @@ static inline void dat_writer_program_init(PIO pio, uint sm, uint offset) {
     pio_sm_set_pins_with_mask(pio, sm, 1 << PIN_PSX_ACK, 1 << PIN_PSX_ACK);
     pio_sm_set_consecutive_pindirs(pio, sm, PIN_PSX_ACK, 1, true);
     pio_gpio_init(pio, PIN_PSX_ACK);
+    /* ...but keep it open drain for now to prevent damage if plugged into a PS1 */
+    gpio_set_outover(PIN_PSX_ACK, GPIO_OVERRIDE_LOW);
+    gpio_set_oeover(PIN_PSX_ACK, GPIO_OVERRIDE_LOW);
 
     /* configure DAT pin for output */
     pio_sm_set_pins_with_mask(pio, sm, 1 << PIN_PSX_DAT, 1 << PIN_PSX_DAT);
     pio_sm_set_consecutive_pindirs(pio, sm, PIN_PSX_DAT, 1, true);
     pio_gpio_init(pio, PIN_PSX_DAT);
+    /* ...but keep it Hi-Z for now to prevent damage if plugged into a PS1 */
+    gpio_set_oeover(PIN_PSX_DAT, GPIO_OVERRIDE_LOW);
 
     /* SEL and CLK used as "wait" inputs only */
     pio_sm_set_consecutive_pindirs(pio, sm, PIN_PSX_SEL, 1, false);

--- a/src/ps2/card_emu/ps2_memory_card.c
+++ b/src/ps2/card_emu/ps2_memory_card.c
@@ -243,15 +243,19 @@ static void __time_critical_func(mc_main_loop)(void) {
                 /* sub cmd */
                 receive(&cmd);
 
-                /* release ACK */
-                gpio_set_oeover(PIN_PSX_ACK, GPIO_OVERRIDE_LOW);
-
                 if (cmd == PS2_SIO2_CMD_0x11) {
                     log(LOG_INFO, "PS2 host confirmed, enabling ACK and DAT push-pull drivers\n");
                     gpio_set_outover(PIN_PSX_ACK, GPIO_OVERRIDE_NORMAL);
                     gpio_set_oeover(PIN_PSX_ACK, GPIO_OVERRIDE_NORMAL);
                     gpio_set_oeover(PIN_PSX_DAT, GPIO_OVERRIDE_NORMAL);
+
+                    /* resp to 0x11 */
+                    ps2_mc_cmd_0x11();
+
                     ps2_host_confirmed = true;
+                } else {
+                    /* release ACK */
+                    gpio_set_oeover(PIN_PSX_ACK, GPIO_OVERRIDE_LOW);
                 }
                 continue;
             }

--- a/src/ps2/card_emu/ps2_memory_card.c
+++ b/src/ps2/card_emu/ps2_memory_card.c
@@ -44,6 +44,8 @@ volatile bool card_active;
 
 static volatile int mc_exit_request, mc_exit_response, mc_enter_request, mc_enter_response;
 
+static bool ps2_host_confirmed = false;
+
 static inline void __time_critical_func(RAM_pio_sm_drain_tx_fifo)(PIO pio, uint sm) {
     uint instr = (pio->sm[sm].shiftctrl & PIO_SM0_SHIFTCTRL_AUTOPULL_BITS) ? pio_encode_out(pio_null, 32) : pio_encode_pull(false, false);
     while (!pio_sm_is_tx_fifo_empty(pio, sm)) {
@@ -231,6 +233,29 @@ static void __time_critical_func(mc_main_loop)(void) {
 
 
         if (cmd == PS2_SIO2_CMD_IDENTIFIER) {
+            // ACK and DAT are normally configured as push-pull outputs for a PS2, but as such they
+            // may damage a PS1 or PS1 multitap. Therefore keep ACK open drain and DAT Hi-Z until
+            // the host is confirmed to be a PS2.
+            if (!ps2_host_confirmed) {
+                /* resp to 0x81 */
+                gpio_set_oeover(PIN_PSX_ACK, GPIO_OVERRIDE_HIGH);
+
+                /* sub cmd */
+                receive(&cmd);
+
+                /* release ACK */
+                gpio_set_oeover(PIN_PSX_ACK, GPIO_OVERRIDE_LOW);
+
+                if (cmd == PS2_SIO2_CMD_0x11) {
+                    log(LOG_INFO, "PS2 host confirmed, enabling ACK and DAT push-pull drivers\n");
+                    gpio_set_outover(PIN_PSX_ACK, GPIO_OVERRIDE_NORMAL);
+                    gpio_set_oeover(PIN_PSX_ACK, GPIO_OVERRIDE_NORMAL);
+                    gpio_set_oeover(PIN_PSX_DAT, GPIO_OVERRIDE_NORMAL);
+                    ps2_host_confirmed = true;
+                }
+                continue;
+            }
+
             //Don't respond to mcman after a card switch to trigger its internal reset
             if (mmceman_mcman_retry_counter > 0) {
                 log(LOG_WARN, "Ignoring mcman for another %i requests\n", mmceman_mcman_retry_counter);


### PR DESCRIPTION
A single sd2psXtd card can easily hold both the PS1 and PS2 saves of an avid player. Therefore one could be tempted to use the same card on their PS1 and PS2 consoles. But currently there is a risk: if the card is set to PS2 mode for use on a PS2, and then later plugged into a PS1 (or worse, PS1 multitap) while still in PS2 mode, it can damage the console or the multitap.

That is because a PS2 memory card has to act push-pull to keep up with PS2 clock. Meanwhile on a PS1 the controller and the memory card share the same bus. As long as both memory card and controller act open drain, everything is fine. But if the memory card starts pushing high, then each time the controller pulls low there is a short. And that happens constantly in response to the console constantly polling the controller.

This PR attempts to mitigate this risk by initializing the involved pins as open drain or Hi-Z, and switching them to push-pull only when the host has been confirmed to be a PS2. This is asserted by watching for the 0x11 subcommand, which should be first subcommand a PS2 emits towards a newly inserted memory card, whereas a PS1 should theoretically never emit that byte as a memory card subcommand. I have tested this on my own PS2 and SuperStation One (I do not own a genuine PS1) and can confirm the PS2 is properly and exclusively detected.

With that, players won't have to worry anymore about which state they left the card in the last time they played. If they forgot it's in PS2 mode and insert it into a PS1 / PS1 multitap, it should be fine.

It's not foolproof, though. At least two edge cases where the pins can still be driven high under a PS1:

- Some PS1 homebrew emits 0x11 memory card subcommand, which trigger PS2 detection
- The card is booted under a PS2 then moved to a PS1 while still being powered on. Possible using a USB-C cable, unlikely to happen by accident.

Therefore I haven't completely removed the warnings in the README and GUI, but I made them less alarming.

I'm looking forward for your feedbacks