### PR TITLE
ps2: make a card switch survive a core1 that is stuck mid-command

### DIFF
--- a/src/ps2/card_emu/ps2_mc_data_interface.c
+++ b/src/ps2/card_emu/ps2_mc_data_interface.c
@@ -341,6 +341,17 @@ bool __time_critical_func(ps2_mc_data_interface_delay_required)(void) {
     return delay_reuired;
 }
 
+/* Called by core0 after it hard-reset core1 during a card switch. Core1
+ * may have died between ps2_mc_data_interface_start_dma() taking the
+ * dirty spinlock and the DMA completion IRQ releasing it. */
+void ps2_mc_data_interface_reset(void) {
+#if WITH_PSRAM
+    psram_wait_for_dma();
+    dma_in_progress = false;
+    ps2_dirty_unlock();
+#endif
+}
+
 void ps2_mc_data_interface_flush(void) {
     while ((sdmode && (op_fill_status() > 0))
     #ifdef WITH_PSRAM

--- a/src/ps2/card_emu/ps2_mc_data_interface.h
+++ b/src/ps2/card_emu/ps2_mc_data_interface.h
@@ -44,3 +44,4 @@ bool ps2_mc_data_interface_get_sdmode(void);
 void ps2_mc_data_interface_task(void);
 void ps2_mc_data_interface_init(void);
 void ps2_mc_data_interface_flush(void);
+void ps2_mc_data_interface_reset(void);

--- a/src/ps2/card_emu/ps2_memory_card.c
+++ b/src/ps2/card_emu/ps2_memory_card.c
@@ -12,6 +12,8 @@
 #include "ps2_mc_commands.h"
 #include "ps2_mc_internal.h"
 #include "mmceman/ps2_mmceman.h"
+#include "ps2_mc_data_interface.h"
+#include "ps2_memory_card.h"
 #include "mmceman/ps2_mmceman_commands.h"
 #include "mmceman/ps2_mmceman_fs.h"
 #include "ps2_mc_spi.pio.h"
@@ -123,6 +125,11 @@ uint8_t __time_critical_func(receive)(uint8_t *cmd) {
             if (reset) {
                 return RECEIVE_RESET;
             }
+            /* a card switch must be able to interrupt a command the
+             * console stopped clocking mid-way (e.g. it was reset) */
+            if (mc_exit_request) {
+                return RECEIVE_RESET;
+            }
         }
         (*cmd) = (pio_sm_get(pio0, cmd_reader.sm) >> 24);
         return RECEIVE_OK;
@@ -151,7 +158,13 @@ uint8_t __time_critical_func(receiveFirst)(uint8_t *cmd) {
 }
 
 void __time_critical_func(mc_respond)(uint8_t ch) {
-    pio_sm_put_blocking(pio0, dat_writer.sm, ch);
+    /* same as pio_sm_put_blocking, but do not wait forever on a console
+     * that stopped clocking when a card switch wants this core back */
+    while (pio_sm_is_tx_fifo_full(pio0, dat_writer.sm)) {
+        if (mc_exit_request)
+            return;
+    }
+    pio_sm_put(pio0, dat_writer.sm, ch);
 }
 
 
@@ -450,8 +463,16 @@ void ps2_memory_card_exit(void) {
     mc_exit_request = 1;
     while (!mc_exit_response) {
         if (time_us_64() > exit_timeout) {
+            /* core1 did not come back: reset it and start it again. The
+             * restarted core must be able to claim the PIO state machines
+             * (they are still claimed by the dead run, and pio_claim_unused_sm
+             * panics on that) and must not inherit a spinlock the dead run
+             * was holding for an in-flight PSRAM DMA. */
+            log(LOG_WARN, "EXIT core1 did not ack in 1s - hard reset\n");
             multicore_reset_core1();
+            ps2_mc_data_interface_reset();
             multicore_launch_core1(ps2_memory_card_main);
+            exit_timeout = time_us_64() + (1000 * 1000);
         }
     };
     mc_exit_request = mc_exit_response = 0;

--- a/src/ps2/mmceman/ps2_mmceman.c
+++ b/src/ps2/mmceman/ps2_mmceman.c
@@ -131,9 +131,11 @@ void ps2_mmceman_task(void) {
         ps2_history_tracker_init();
 
         // close old card
+        log(LOG_TRACE, "SW1 exit (retry=%u)\n", mmceman_mcman_retry_counter);
         ps2_memory_card_exit();
         log(LOG_TRACE, "%s After Exit\n", __func__);
         ps2_mc_data_interface_flush();
+        log(LOG_TRACE, "SW3 flush done\n");
         ps2_cardman_close();
         log(LOG_TRACE, "%s After Close\n", __func__);
 
@@ -151,8 +153,11 @@ void ps2_mmceman_task(void) {
         mmceman_mcman_retry_counter = 5;
 
         // open new card
+        log(LOG_TRACE, "SW5 open\n");
         ps2_cardman_open();
+        log(LOG_TRACE, "SW6 open done\n");
         ps2_memory_card_enter();
+        log(LOG_TRACE, "SW7 enter done\n");
 
         log(LOG_INFO, "%s Card switch took %u ms\n", __func__, (time_us_32() - switching_time)/1000U);
     }


### PR DESCRIPTION
Reproducible on stock 1.4.0: switch cards while the console is mid-transaction and gets reset. core1 sits in `receive()` waiting for a byte that never comes, watching only the console-reset flag, so it never acknowledges the exit request. The 1 s recovery in `ps2_memory_card_exit()` then hard-resets and relaunches core1, the relaunched core re-claims PIO state machines still claimed by the dead run and panics, once a second, forever: dead card, dead USB, only a power cycle helps. Silent on release builds.

- `receive()` and `mc_respond()` also honour the exit request
- the recovery path releases the dirty spinlock the dead core may have held for an in-flight PSRAM DMA and re-arms its timeout instead of resetting core1 on every loop iteration
- each card-switch step logs at LOG_TRACE

The boot change that used to be in this PR is now #107, as suggested. This PR is only the hang fix.

Evidence, all on real Namco System 246/256 hardware through the production load path:
- with only the `receive()` exit check removed and everything else as shipped: 4 hangs in 10 switches (table in the comments below)
- with none of this PR in the build (1.4.0 plus only the boot change from #107): 4 hangs in 51 switches tonight, three of them switching away from a game about 20 s after it booted
- with this PR in: 0 hangs over several hundred switches across both cabinets since 2026-09-04
