### PR TITLE
ps2: arcade variants no longer need a second console reset after a card switch

### DIFF
--- a/src/ps2/mmceman/ps2_mmceman.c
+++ b/src/ps2/mmceman/ps2_mmceman.c
@@ -147,8 +147,13 @@ void ps2_mmceman_task(void) {
         /* Set retry counter to stop the sd2psx from
          * responding to the next 5 requests from mcman.
          * This causes mmcman to clear it's cache and invalidate
-         * handles, preventing a cache flush bug from causing corruption */
-        mmceman_mcman_retry_counter = 5;
+         * handles, preventing a cache flush bug from causing corruption.
+         * Arcade variants (COH, SC2) identify the card once at boot and do
+         * not retry, so they get no refusals. */
+        if ((settings_get_ps2_variant() == PS2_VARIANT_COH) || (settings_get_ps2_variant() == PS2_VARIANT_SC2))
+            mmceman_mcman_retry_counter = 0;
+        else
+            mmceman_mcman_retry_counter = 5;
 
         // open new card
         ps2_cardman_open();


### PR DESCRIPTION
On every card switch the firmware refuses the next five card-identifier requests so a PS2's mcman drops its cache. Arcade BIOSes (Namco System 246/256: the COH and SC2 variants) identify the card once at boot and give up, so the first boot after any switch fails with "Boot Program Error" and a second reset is needed. Those boards have no mcman cache to protect.

This is the boot half of #104, split out as requested and in the form suggested there: the existing `mmceman_mcman_retry_counter = 5` in the card-switch task is guarded by a variant check and set to 0 on COH and SC2. Retail and Proto are unchanged.

Tested tonight as exactly this change on top of 1.4.0 (nothing else from #104 in the build), on a Namco System 256 with a Raspberry Pi driving the SD2PSX over USB-CDC through the same load path the cabinets use: 30 titles, one card each, every one booted on a single reset release. The core1 exit fix stays in #104; it is independent of this change (the same run also reproduced that hang, numbers there).
